### PR TITLE
feat: add dark mode with persistent theme toggle

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -2,14 +2,41 @@
 
 :root {
     --primary-color: #2F3C7E;
-    /* 60% of the page color */
     --secondary-color: #FBEAEB;
-    /* 30% of the page color */
     --background-color: #E1E5E6;
-    /* 10% additional color */
     --text-color: #2c3e50;
     --border-color: #d1d8e0;
     --hover-color: #ff6b6b;
+    --container-bg: #ffffff;
+    --table-cell-bg: #ffffff;
+    --modal-bg: #ffffff;
+    --slot-grid-bg: #f5f5f5;
+    --selected-slots-bg: #e8f4fc;
+    --venue-color: #333;
+    --faculty-color: #555;
+    --input-bg: #ffffff;
+    --cancel-btn-bg: #95a5a6;
+    --cancel-btn-hover: #7f8c8d;
+}
+
+/* ===== DARK MODE VARIABLES ===== */
+[data-theme="dark"] {
+    --primary-color: #4a5fc1;
+    --secondary-color: #1a1a2e;
+    --background-color: #16213e;
+    --text-color: #e0e0e0;
+    --border-color: #3a3a5c;
+    --hover-color: #ff6b6b;
+    --container-bg: #1e1e3a;
+    --table-cell-bg: #252545;
+    --modal-bg: #1e1e3a;
+    --slot-grid-bg: #2a2a4a;
+    --selected-slots-bg: #1a3550;
+    --venue-color: #b0b0d0;
+    --faculty-color: #9090b8;
+    --input-bg: #2a2a4a;
+    --cancel-btn-bg: #4a4a6a;
+    --cancel-btn-hover: #5a5a7a;
 }
 
 body {
@@ -21,16 +48,18 @@ body {
     color: var(--text-color);
     margin: 0;
     padding: 20px;
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .container {
     max-width: 900px;
     margin: 0 auto;
     padding: 20px;
-    background-color: white;
+    background-color: var(--container-bg);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     border-radius: 8px;
     text-align: center;
+    transition: background-color 0.3s ease;
 }
 
 h1 {
@@ -41,6 +70,72 @@ h1 {
     font-weight: 600;
 }
 
+/* ===== DARK MODE TOGGLE ===== */
+.dark-mode-toggle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.dark-mode-toggle .toggle-label {
+    font-size: 0.95rem;
+    color: white;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.toggle-switch {
+    position: relative;
+    width: 52px;
+    height: 26px;
+    flex-shrink: 0;
+}
+
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    position: absolute;
+}
+
+.toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background-color: rgba(255, 255, 255, 0.25);
+    border-radius: 26px;
+    transition: background-color 0.3s ease;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.toggle-slider::before {
+    content: "☀️";
+    position: absolute;
+    height: 20px;
+    width: 20px;
+    left: 3px;
+    bottom: 2px;
+    border-radius: 50%;
+    transition: transform 0.3s ease, content 0.3s ease;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+}
+
+.toggle-switch input:checked + .toggle-slider {
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+.toggle-switch input:checked + .toggle-slider::before {
+    content: "🌙";
+    transform: translateX(26px);
+}
+
+/* ===== TOP BAR ===== */
 .top-bar {
     display: flex;
     justify-content: space-between;
@@ -51,6 +146,8 @@ h1 {
     color: white;
     border-radius: 8px;
     margin-bottom: 15px;
+    transition: background-color 0.3s ease;
+    gap: 12px;
 }
 
 .top-bar a {
@@ -67,8 +164,7 @@ h1 {
     font-size: 1.2rem;
 }
 
-/* Form Styles */
-
+/* ===== FORM STYLES ===== */
 .form-row {
     display: flex;
     justify-content: center;
@@ -91,6 +187,9 @@ input[type="text"] {
     border-radius: 4px;
     font-size: 1.25em;
     margin-right: 10px;
+    background-color: var(--input-bg);
+    color: var(--text-color);
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
 button {
@@ -106,7 +205,7 @@ button {
     font-style: normal;
     font-size: 1.1em;
     box-shadow: rgba(17, 12, 46, 0.15) 0px 48px 100px 0px;
-    transition: box-shadow 0.3s ease;
+    transition: box-shadow 0.3s ease, background-color 0.3s ease;
 }
 
 button:hover {
@@ -161,8 +260,7 @@ button:hover {
     transform: scale(1);
 }
 
-/* Table Styles */
-
+/* ===== TABLE STYLES ===== */
 table {
     margin-top: 10px;
     width: 100%;
@@ -177,16 +275,18 @@ td {
     border: 1px solid var(--border-color);
     padding: 6px;
     text-align: center;
+    transition: border-color 0.3s ease;
 }
 
 th {
     background-color: var(--primary-color);
     color: white;
+    transition: background-color 0.3s ease;
 }
 
 td {
-    background-color: white;
-    transition: transform 0.3s ease;
+    background-color: var(--table-cell-bg);
+    transition: transform 0.3s ease, background-color 0.3s ease;
 }
 
 td:hover {
@@ -195,8 +295,7 @@ td:hover {
     box-shadow: inset 0 0 4px #000000;
 }
 
-/* Subject Table Styles */
-
+/* ===== SUBJECT TABLE STYLES ===== */
 .download-format {
     margin: 1rem 0;
 }
@@ -217,6 +316,11 @@ td:hover {
     background-color: var(--primary-color);
 }
 
+#subjectTable td {
+    background-color: var(--table-cell-bg);
+    color: var(--text-color);
+}
+
 .delete-btn {
     background-color: var(--hover-color);
     color: white;
@@ -231,8 +335,7 @@ td:hover {
     background-color: #e55656;
 }
 
-/* Footer Styles */
-
+/* ===== FOOTER STYLES ===== */
 footer {
     margin-top: 25px;
     display: flex;
@@ -243,6 +346,7 @@ footer {
     color: white;
     border-radius: 8px;
     font-size: 1.2em;
+    transition: background-color 0.3s ease;
 }
 
 footer .left-section {
@@ -286,15 +390,8 @@ footer .right-section {
 }
 
 @keyframes heartbeat {
-
-    0%,
-    100% {
-        transform: scale(0.8);
-    }
-
-    50% {
-        transform: scale(1.2);
-    }
+    0%, 100% { transform: scale(0.8); }
+    50% { transform: scale(1.2); }
 }
 
 footer a {
@@ -307,135 +404,7 @@ footer a:hover {
     text-decoration: underline;
 }
 
-/* Responsive Design */
-
-@media (max-width: 768px) {
-    .container {
-        padding: 15px;
-    }
-
-    h1 {
-        font-size: 1.4em;
-    }
-
-    table {
-        font-size: 0.75em;
-    }
-
-    th,
-    td {
-        padding: 5px;
-    }
-
-    p {
-        font-size: 0.75em;
-    }
-
-    input[type="number"],
-    input[type="text"] {
-        font-size: 0.75em;
-    }
-
-    img {
-        width: 100px;
-    }
-
-    button {
-        font-size: 0.5em;
-        margin-top: 10px;
-    }
-
-    a {
-        font-size: 0.75em;
-    }
-
-    footer a {
-        font-size: 0.85em;
-    }
-}
-
-@media (max-width: 480px) {
-    h1 {
-        font-size: 1.2em;
-    }
-
-    .top-bar #top-link {
-        font-size: 0.75rem;
-        margin-right: 10px;
-    }
-
-    table {
-        font-size: 0.7em;
-    }
-
-    th,
-    td {
-        padding: 4px;
-    }
-
-    .input-group {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
-    .input-group label {
-        margin-bottom: 5px;
-    }
-
-    p {
-        font-size: 0.75em;
-    }
-
-    input[type="number"],
-    input[type="text"] {
-        font-size: 0.75em;
-    }
-
-    img {
-        width: 100px;
-    }
-
-    button {
-        font-size: 0.75em;
-        margin-top: 10px;
-    }
-
-    footer a {
-        font-size: 1em;
-    }
-
-    footer {
-        font-size: 0.85em;
-    }
-
-    footer .right-section .social-icons {
-        font-size: .60rem;
-    }
-
-    footer .right-section .social-icons img {
-        width: 15px;
-        height: 15px;
-    }
-}
-
-/* Subtle animation for table cells */
-
-@keyframes cellHighlight {
-    0% {
-        background-color: var(--primary-color);
-        opacity: 0.1;
-    }
-
-    100% {
-        background-color: transparent;
-    }
-}
-
-.highlight {
-    animation: cellHighlight 0.3s ease-out;
-}
-
-/* Slot Info Styles */
+/* ===== SLOT INFO STYLES ===== */
 .slot-info {
     display: flex;
     flex-direction: column;
@@ -463,7 +432,7 @@ footer a:hover {
 .slot-info .venue-info {
     font-size: 0.65em;
     font-style: italic;
-    color: #333;
+    color: var(--venue-color);
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -472,14 +441,14 @@ footer a:hover {
 
 .slot-info .faculty-name {
     font-size: 0.6em;
-    color: #555;
+    color: var(--faculty-color);
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-/* Action Cell Styles */
+/* ===== ACTION CELL STYLES ===== */
 .action-cell {
     display: flex;
     gap: 5px;
@@ -501,7 +470,7 @@ footer a:hover {
     background-color: #2980b9;
 }
 
-/* Modal Styles */
+/* ===== MODAL STYLES ===== */
 .modal {
     display: none;
     position: fixed;
@@ -516,25 +485,20 @@ footer a:hover {
 }
 
 .modal-content {
-    background-color: white;
+    background-color: var(--modal-bg);
+    color: var(--text-color);
     padding: 25px;
     border-radius: 10px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
     max-width: 450px;
     width: 90%;
     animation: modalSlideIn 0.3s ease;
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 @keyframes modalSlideIn {
-    from {
-        opacity: 0;
-        transform: translateY(-30px);
-    }
-
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+    from { opacity: 0; transform: translateY(-30px); }
+    to { opacity: 1; transform: translateY(0); }
 }
 
 .modal-content h2 {
@@ -563,6 +527,9 @@ footer a:hover {
     border-radius: 5px;
     font-size: 1em;
     box-sizing: border-box;
+    background-color: var(--input-bg);
+    color: var(--text-color);
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
 .modal-field input:focus {
@@ -600,30 +567,32 @@ footer a:hover {
 }
 
 .cancel-btn {
-    background-color: #95a5a6;
+    background-color: var(--cancel-btn-bg);
     color: white;
     padding: 10px 20px;
     border: none;
     border-radius: 5px;
     cursor: pointer;
     font-size: 1em;
+    transition: background-color 0.3s ease;
 }
 
 .cancel-btn:hover {
-    background-color: #7f8c8d;
+    background-color: var(--cancel-btn-hover);
 }
 
-/* Edit Slots Grid */
+/* ===== EDIT SLOTS GRID ===== */
 .edit-slots-grid {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
     gap: 5px;
     margin-top: 10px;
     padding: 10px;
-    background: #f5f5f5;
+    background: var(--slot-grid-bg);
     border-radius: 8px;
     max-height: 200px;
     overflow-y: auto;
+    transition: background-color 0.3s ease;
 }
 
 .edit-slot-btn {
@@ -631,11 +600,12 @@ footer a:hover {
     text-align: center;
     font-size: 0.75em;
     font-weight: 600;
-    border: 2px solid #ddd;
+    border: 2px solid var(--border-color);
     border-radius: 4px;
     cursor: pointer;
     transition: all 0.2s ease;
-    background: white;
+    background: var(--table-cell-bg);
+    color: var(--text-color);
 }
 
 .edit-slot-btn:hover {
@@ -663,62 +633,109 @@ footer a:hover {
 .selected-slots-display {
     margin-top: 10px;
     padding: 8px 12px;
-    background: #e8f4fc;
+    background: var(--selected-slots-bg);
     border-radius: 5px;
     font-size: 0.9em;
     color: var(--primary-color);
+    transition: background-color 0.3s ease;
 }
 
 .selected-slots-display span {
     font-weight: 600;
 }
 
+/* ===== DARK MODE PAGE LABEL ===== */
+p {
+    color: var(--text-color);
+}
+
+label {
+    color: var(--text-color);
+}
+
+/* ===== ANIMATIONS ===== */
+@keyframes cellHighlight {
+    0% { background-color: var(--primary-color); opacity: 0.1; }
+    100% { background-color: transparent; }
+}
+
+.highlight {
+    animation: cellHighlight 0.3s ease-out;
+}
+
+/* ===== RESPONSIVE ===== */
 @media (max-width: 768px) {
-    .slot-info .subject-name {
-        font-size: 0.55em;
-    }
+    .container { padding: 15px; }
+    h1 { font-size: 1.4em; }
+    table { font-size: 0.75em; }
+    th, td { padding: 5px; }
+    p { font-size: 0.75em; }
 
-    .slot-info .venue-info {
+    input[type="number"],
+    input[type="text"] { font-size: 0.75em; }
+
+    img { width: 100px; }
+
+    button {
         font-size: 0.5em;
+        margin-top: 10px;
     }
 
-    .slot-info .faculty-name {
-        font-size: 0.5em;
-    }
+    a { font-size: 0.75em; }
+    footer a { font-size: 0.85em; }
 
-    .modal-content {
-        padding: 15px;
-    }
+    .slot-info .subject-name { font-size: 0.55em; }
+    .slot-info .venue-info { font-size: 0.5em; }
+    .slot-info .faculty-name { font-size: 0.5em; }
 
-    .modal-buttons {
-        flex-direction: column;
-    }
+    .modal-content { padding: 15px; }
+    .modal-buttons { flex-direction: column; }
+    .edit-slots-grid { grid-template-columns: repeat(5, 1fr); }
 
-    .edit-slots-grid {
-        grid-template-columns: repeat(5, 1fr);
-    }
+    .dark-mode-toggle .toggle-label { display: none; }
 }
 
 @media (max-width: 480px) {
-    .slot-info .slot-id {
-        font-size: 0.8em;
+    h1 { font-size: 1.2em; }
+
+    .top-bar #top-link {
+        font-size: 0.75rem;
+        margin-right: 10px;
     }
 
-    .slot-info .subject-name {
-        font-size: 0.5em;
-    }
+    table { font-size: 0.7em; }
+    th, td { padding: 4px; }
 
-    .slot-info .venue-info {
-        font-size: 0.45em;
-    }
-
-    .slot-info .faculty-name {
-        font-size: 0.45em;
-    }
-
-    .action-cell {
+    .input-group {
         flex-direction: column;
+        align-items: flex-start;
     }
+
+    .input-group label { margin-bottom: 5px; }
+    p { font-size: 0.75em; }
+
+    input[type="number"],
+    input[type="text"] { font-size: 0.75em; }
+
+    img { width: 100px; }
+
+    button {
+        font-size: 0.75em;
+        margin-top: 10px;
+    }
+
+    footer a { font-size: 1em; }
+    footer { font-size: 0.85em; }
+
+    footer .right-section .social-icons { font-size: .60rem; }
+    footer .right-section .social-icons img { width: 15px; height: 15px; }
+
+    .slot-info .slot-id { font-size: 0.8em; }
+    .slot-info .subject-name { font-size: 0.5em; }
+    .slot-info .venue-info { font-size: 0.45em; }
+    .slot-info .faculty-name { font-size: 0.45em; }
+
+    .action-cell { flex-direction: column; }
 
     .edit-btn,
     .delete-btn {

--- a/JS/main.js
+++ b/JS/main.js
@@ -2,7 +2,36 @@ let selectedColor = '';
 let selectedSlots = new Set();
 let subjectData = [];
 
-// Function to generate color pickers (unchanged)
+// ===================== DARK MODE =====================
+
+function toggleDarkMode() {
+    const checkbox = document.getElementById('darkModeCheckbox');
+    const label = document.getElementById('toggleLabel');
+    if (checkbox.checked) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        label.textContent = 'Light Mode';
+        localStorage.setItem('theme', 'dark');
+    } else {
+        document.documentElement.removeAttribute('data-theme');
+        label.textContent = 'Dark Mode';
+        localStorage.setItem('theme', 'light');
+    }
+}
+
+// Apply saved theme on page load
+(function applySavedTheme() {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark') {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        const checkbox = document.getElementById('darkModeCheckbox');
+        const label = document.getElementById('toggleLabel');
+        if (checkbox) checkbox.checked = true;
+        if (label) label.textContent = 'Light Mode';
+    }
+})();
+
+// ===================== COLOR PICKERS =====================
+
 function generateColorPickers() {
     const count = document.getElementById('subjectCount').value;
     const container = document.getElementById('colorPickers');
@@ -17,36 +46,27 @@ function generateColorPickers() {
     }
 }
 
-// Function to get random pastel color (unchanged)
 function getRandomPastelColorRGB() {
-    const r = Math.floor((Math.random() * 127) + 127); // Range: 127-254 (lighter shades)
+    const r = Math.floor((Math.random() * 127) + 127);
     const g = Math.floor((Math.random() * 127) + 127);
     const b = Math.floor((Math.random() * 127) + 127);
-
     return `rgb(${r}, ${g}, ${b})`;
 }
 
-// Check if a color is already used by another subject
 function isColorUsed(color) {
     return subjectData.some(data => data.color === color);
 }
 
-// Function to select color
 function selectColor(color) {
     if (selectedSlots.size > 0) {
         alert("Please add the selected slots to the table before changing the color.");
         return;
     }
-
-    // Check if color is already used
     if (isColorUsed(color)) {
         alert("⚠️ This color is already used for another subject!\n\nPlease select a different color to avoid confusion.");
         return;
     }
-
     selectedColor = color;
-
-    // Highlight the selected color picker
     document.querySelectorAll('.color-option').forEach(picker => {
         picker.classList.remove('selected-picker');
         if (picker.style.backgroundColor === color) {
@@ -55,9 +75,9 @@ function selectColor(color) {
     });
 }
 
-// Function to handle timetable cell click
+// ===================== TIMETABLE CLICK =====================
+
 document.getElementById('timetable').addEventListener('click', (e) => {
-    // Handle clicks on td or its children (like venue-info spans)
     let targetCell = e.target;
     if (targetCell.tagName !== 'TD') {
         targetCell = targetCell.closest('td');
@@ -68,9 +88,8 @@ document.getElementById('timetable').addEventListener('click', (e) => {
 
     if (selectedColor) {
         if (currentColor === selectedColor) {
-            // Deselect the slot
             targetCell.style.backgroundColor = '';
-            targetCell.innerHTML = targetCell.id; // Reset to slot ID
+            targetCell.innerHTML = targetCell.id;
             selectedSlots.delete(targetCell.id);
         } else if (!currentColor) {
             targetCell.style.backgroundColor = selectedColor;
@@ -83,25 +102,22 @@ document.getElementById('timetable').addEventListener('click', (e) => {
     }
 });
 
-// Function to handle form submission
+// ===================== FORM SUBMISSION =====================
+
 document.getElementById('subjectForm').addEventListener('submit', (e) => {
     e.preventDefault();
     const subject = document.getElementById('subjectName').value;
     const faculty = document.getElementById('facultyName').value;
     const venue = document.getElementById('venueName').value || '';
 
-    // Check if color is selected
     if (!selectedColor) {
         alert('Please select a color first');
         return;
     }
-
-    // Double-check color is not already used (in case of edge cases)
     if (isColorUsed(selectedColor)) {
         alert("⚠️ This color is already used for another subject!\n\nPlease select a different color.");
         return;
     }
-
     if (selectedSlots.size > 0) {
         addSubjectData(subject, faculty, venue);
         updateTimetableWithSubjectInfo();
@@ -114,7 +130,6 @@ document.getElementById('subjectForm').addEventListener('submit', (e) => {
     }
 });
 
-// Mark colors that are already used
 function markUsedColors() {
     document.querySelectorAll('.color-option').forEach(picker => {
         const color = picker.style.backgroundColor;
@@ -126,7 +141,6 @@ function markUsedColors() {
     });
 }
 
-// Function to add subject data
 function addSubjectData(subject, faculty, venue) {
     subjectData.push({
         id: subjectData.length + 1,
@@ -138,7 +152,6 @@ function addSubjectData(subject, faculty, venue) {
     });
 }
 
-// Function to update timetable cells with subject info
 function updateTimetableWithSubjectInfo() {
     const latestSubject = subjectData[subjectData.length - 1];
     latestSubject.slots.forEach(slotId => {
@@ -156,7 +169,6 @@ function updateTimetableWithSubjectInfo() {
     });
 }
 
-// Function to update subject table
 function updateSubjectTable() {
     const tbody = document.querySelector('#subjectTable tbody');
     tbody.innerHTML = '';
@@ -170,7 +182,6 @@ function updateSubjectTable() {
         const colorCell = row.insertCell(5);
         colorCell.style.backgroundColor = data.color;
 
-        // Action buttons container
         const actionCell = row.insertCell(6);
         actionCell.className = 'action-cell';
 
@@ -188,24 +199,22 @@ function updateSubjectTable() {
     });
 }
 
-// Function to delete a subject
 function deleteSubject(index) {
     const slotsToClear = subjectData[index].slots;
     subjectData.splice(index, 1);
     slotsToClear.forEach(slotId => {
         const cell = document.getElementById(slotId);
         cell.style.backgroundColor = '';
-        cell.innerHTML = slotId; // Reset to just the slot ID
+        cell.innerHTML = slotId;
     });
     reapplySubjectColors();
     updateSubjectTable();
-    markUsedColors(); // Update color availability
+    markUsedColors();
     if (subjectData.length === 0) {
         disableDownloadButton();
     }
 }
 
-// Function to reapply subject colors and info
 function reapplySubjectColors() {
     subjectData.forEach(data => {
         data.slots.forEach(slotId => {
@@ -223,7 +232,6 @@ function reapplySubjectColors() {
     });
 }
 
-// Function to reset form
 function resetForm() {
     document.getElementById('subjectName').value = '';
     document.getElementById('facultyName').value = '';
@@ -232,19 +240,18 @@ function resetForm() {
     selectedColor = '';
 }
 
-// Function to enable download button
 function enableDownloadButton() {
     document.getElementById('downloadBtn').disabled = false;
 }
 
-// Function to disable download button
 function disableDownloadButton() {
     document.getElementById('downloadBtn').disabled = true;
 }
 
-// Handle download button click
+// ===================== DOWNLOAD =====================
+
 document.getElementById('downloadBtn').addEventListener('click', (e) => {
-    e.preventDefault(); // Prevent default behavior
+    e.preventDefault();
     const format = document.querySelector('input[name="downloadFormat"]:checked').value;
     if (format === 'pdf') {
         downloadAsPDF();
@@ -253,19 +260,16 @@ document.getElementById('downloadBtn').addEventListener('click', (e) => {
     }
 });
 
-// --------------Function to download timetable and subject table as PDF
-
 function downloadAsPDF() {
-    const { jsPDF } = window.jspdf; // jsPDF library
-    const doc = new jsPDF(); // create a new jsPDF object, storing it under the variable, doc.
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
 
-    // Add timetable to PDF
-    doc.text('Timetable', 10, 10); // a headline of Timetable
-    doc.autoTable({ // autoTable is a method from the jsPDF library used to create a table in the PDF
-        html: '#timetable', // get the timetable id from the html
+    doc.text('Timetable', 10, 10);
+    doc.autoTable({
+        html: '#timetable',
         startY: 20,
         styles: { cellPadding: 2 },
-        didParseCell: function (data) { // didParseCell is a callback function that is excuted in each cell that checks the raw html element to see its content and passes style to the pdf if the html contains a style attribute
+        didParseCell: function (data) {
             const td = data.cell.raw;
             if (td.hasAttribute('style')) {
                 const backgroundColor = td.style.backgroundColor;
@@ -277,10 +281,7 @@ function downloadAsPDF() {
         }
     });
 
-    // Add a page break before the subject table
     doc.addPage();
-
-    // Add subject table to PDF
     doc.text('Subject Table', 10, 10);
     doc.autoTable({
         html: '#subjectTable',
@@ -298,59 +299,47 @@ function downloadAsPDF() {
         }
     });
 
-    // Save the PDF
     doc.save('timetable_and_subjects.pdf');
 }
-
-
-//------------------- Function to download timetable and subject table as JPEG
 
 function downloadAsJPEG() {
     const tempContainer = document.createElement('div');
     tempContainer.style.position = 'absolute';
-    tempContainer.style.top = '-9999px'; // Hide it from view
+    tempContainer.style.top = '-9999px';
     document.body.appendChild(tempContainer);
-
-    // create a clone of both the timetable and subject table
 
     const timetable = document.getElementById('timetable').cloneNode(true);
     const subjectTable = document.getElementById('subjectTable').cloneNode(true);
     tempContainer.appendChild(timetable);
     tempContainer.appendChild(subjectTable);
 
-
-    //convert the cloned html to canvas using the html2canvas library, and making sure the backgroundcolor is null (transparent)
-
     html2canvas(tempContainer, { backgroundColor: null }).then(canvas => {
         const link = document.createElement('a');
         link.download = 'timetable_and_subjects.jpg';
         link.href = canvas.toDataURL('image/jpeg');
         link.click();
-
         document.body.removeChild(tempContainer);
     });
 }
 
-// Initialize color pickers
+// ===================== INITIALIZE =====================
+
 generateColorPickers();
 
-// ===================== EDIT MODAL FUNCTIONALITY =====================
+// ===================== EDIT MODAL =====================
 
-// All slot IDs in the timetable
 const allSlots = [
-    'A11', 'B11', 'C11', 'A21', 'A14', 'B21', 'C21',  // Monday
-    'D11', 'E11', 'F11', 'D21', 'E14', 'E21', 'F21',  // Tuesday
-    'A12', 'B12', 'C12', 'A22', 'B14', 'B22', 'A24',  // Wednesday
-    'D12', 'E12', 'F12', 'D22', 'F14', 'E22', 'F22',  // Thursday
-    'A13', 'B13', 'C13', 'A23', 'C14', 'B23', 'B24',  // Friday
-    'D13', 'E13', 'F13', 'D23', 'D14', 'D24', 'E23'   // Saturday
+    'A11', 'B11', 'C11', 'A21', 'A14', 'B21', 'C21',
+    'D11', 'E11', 'F11', 'D21', 'E14', 'E21', 'F21',
+    'A12', 'B12', 'C12', 'A22', 'B14', 'B22', 'A24',
+    'D12', 'E12', 'F12', 'D22', 'F14', 'E22', 'F22',
+    'A13', 'B13', 'C13', 'A23', 'C14', 'B23', 'B24',
+    'D13', 'E13', 'F13', 'D23', 'D14', 'D24', 'E23'
 ];
 
-// Track slots selected in edit modal
 let editSelectedSlots = new Set();
 let currentEditIndex = -1;
 
-// Open edit modal
 function openEditModal(index) {
     const data = subjectData[index];
     currentEditIndex = index;
@@ -361,20 +350,17 @@ function openEditModal(index) {
     document.getElementById('editFacultyName').value = data.faculty;
     document.getElementById('editVenueName').value = data.venue || '';
 
-    // Build the slot grid
     buildEditSlotGrid(index, data.color);
     updateSelectedSlotsDisplay();
 
     document.getElementById('editModal').style.display = 'flex';
 }
 
-// Build the interactive slot grid
 function buildEditSlotGrid(editIndex, subjectColor) {
     const grid = document.getElementById('editSlotsGrid');
     grid.innerHTML = '';
 
-    // Get all occupied slots (except current subject)
-    const occupiedSlots = new Map(); // slotId -> color
+    const occupiedSlots = new Map();
     subjectData.forEach((data, idx) => {
         if (idx !== editIndex) {
             data.slots.forEach(slot => {
@@ -383,7 +369,6 @@ function buildEditSlotGrid(editIndex, subjectColor) {
         }
     });
 
-    // Create slot buttons
     allSlots.forEach(slotId => {
         const slotBtn = document.createElement('div');
         slotBtn.className = 'edit-slot-btn';
@@ -391,12 +376,10 @@ function buildEditSlotGrid(editIndex, subjectColor) {
         slotBtn.dataset.slot = slotId;
 
         if (occupiedSlots.has(slotId)) {
-            // Slot is occupied by another subject
             slotBtn.classList.add('occupied');
             slotBtn.style.backgroundColor = occupiedSlots.get(slotId);
             slotBtn.title = 'Occupied by another subject';
         } else if (editSelectedSlots.has(slotId)) {
-            // Slot is selected for this subject
             slotBtn.classList.add('selected');
             slotBtn.style.backgroundColor = subjectColor;
         }
@@ -406,7 +389,6 @@ function buildEditSlotGrid(editIndex, subjectColor) {
     });
 }
 
-// Toggle slot selection in edit modal
 function toggleEditSlot(slotId, subjectColor, occupiedSlots) {
     if (occupiedSlots.has(slotId)) {
         alert('This slot is already occupied by another subject!');
@@ -428,21 +410,18 @@ function toggleEditSlot(slotId, subjectColor, occupiedSlots) {
     updateSelectedSlotsDisplay();
 }
 
-// Update the selected slots display
 function updateSelectedSlotsDisplay() {
     const sortedSlots = Array.from(editSelectedSlots).sort();
     document.getElementById('selectedSlotsCount').textContent = sortedSlots.length;
     document.getElementById('selectedSlotsList').textContent = sortedSlots.join(', ') || 'None';
 }
 
-// Close edit modal
 function closeEditModal() {
     document.getElementById('editModal').style.display = 'none';
     currentEditIndex = -1;
     editSelectedSlots.clear();
 }
 
-// Save edit changes
 function saveEdit() {
     const index = parseInt(document.getElementById('editIndex').value);
     const newSubject = document.getElementById('editSubjectName').value.trim();
@@ -454,7 +433,6 @@ function saveEdit() {
         alert('Subject Name and Faculty Name are required!');
         return;
     }
-
     if (newSlots.length === 0) {
         alert('Please select at least one slot!');
         return;
@@ -463,12 +441,8 @@ function saveEdit() {
     const oldSlots = subjectData[index].slots;
     const color = subjectData[index].color;
 
-    // Find slots to clear (removed slots)
     const slotsToRemove = oldSlots.filter(s => !editSelectedSlots.has(s));
-    // Find slots to add (new slots)
-    const slotsToAdd = newSlots.filter(s => !oldSlots.includes(s));
 
-    // Clear removed slots
     slotsToRemove.forEach(slotId => {
         const cell = document.getElementById(slotId);
         if (cell) {
@@ -477,13 +451,11 @@ function saveEdit() {
         }
     });
 
-    // Update subject data
     subjectData[index].subject = newSubject;
     subjectData[index].faculty = newFaculty;
     subjectData[index].venue = newVenue;
     subjectData[index].slots = newSlots;
 
-    // Update all current slots in timetable
     newSlots.forEach(slotId => {
         const cell = document.getElementById(slotId);
         if (cell) {
@@ -499,18 +471,13 @@ function saveEdit() {
         }
     });
 
-    // Update subject table
     updateSubjectTable();
-
-    // Close modal
     closeEditModal();
 }
 
-// Event listeners for modal
 document.getElementById('saveEditBtn').addEventListener('click', saveEdit);
 document.getElementById('cancelEditBtn').addEventListener('click', closeEditModal);
 
-// Close modal when clicking outside
 document.getElementById('editModal').addEventListener('click', (e) => {
     if (e.target.id === 'editModal') {
         closeEditModal();

--- a/index.html
+++ b/index.html
@@ -21,8 +21,17 @@
         <a href="https://github.com/Cyb3rGhoul/FFCS-VITB-Maker" target="_blank" class="top-link" id="top-link">⭐ Give a
             star to this
             project on GitHub</a>
-        <a href="https://buymeacoffee.com/harshshukla.dev
-        " target="_blank">
+
+        <!-- Dark Mode Toggle -->
+        <label class="dark-mode-toggle" title="Toggle dark mode">
+            <span class="toggle-label" id="toggleLabel">Dark Mode</span>
+            <div class="toggle-switch">
+                <input type="checkbox" id="darkModeCheckbox" onchange="toggleDarkMode()">
+                <span class="toggle-slider"></span>
+            </div>
+        </label>
+
+        <a href="https://buymeacoffee.com/harshshukla.dev" target="_blank">
             <img src="https://www.buymeacoffee.com/assets/img/guidelines/download-assets-sm-1.svg" alt="Buy me a coffee"
                 width="180px" class="coffee-logo">
         </a>
@@ -77,7 +86,6 @@
             <td id="B14">B14</td>
             <td id="B22">B22</td>
             <td id="A24">A24</td>
-
         </tr>
         <tr>
             <th>Thu</th>
@@ -124,7 +132,6 @@
             <label for="downloadJPG">JPEG</label>
         </div>
         <button id="downloadBtn" type="button" disabled>Download Timetable <i class="fas fa-download"></i></button>
-
     </form>
 
     <table id="subjectTable">
@@ -204,8 +211,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.2/jspdf.plugin.autotable.min.js"></script>
 
-
-    <script type="text/javascript" src="JS/main.js "></script>
+    <script type="text/javascript" src="JS/main.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## ✨ Feature: Dark Mode Support

### Summary
This PR introduces a fully functional dark mode to the FFCS VITB Maker, including a persistent theme toggle, a complete dark color palette, and improved UI responsiveness across all components.

---

### 🔀 Commits
| Commit | Description |
|--------|-------------|
| `13155de` | Implement dark mode toggle functionality and apply saved theme on page load |
| `a95f18e` | Added dark mode toggle functionality and cleaned up HTML structure |
| `73ee322` | Enhance CSS for dark mode support and improve UI responsiveness |

---

### 🛠️ Changes Made

**`CSS/style.css`**
- Added a `[data-theme="dark"]` block with a complete set of CSS variable overrides covering background, text, borders, table cells, modal, inputs, slot grid, and buttons
- All interactive elements (body, table cells, modal, inputs, footer, top bar) now use `transition: ... 0.3s ease` for smooth theme switching
- Added styles for the dark mode toggle switch (☀️ / 🌙 emoji slider) embedded in the top bar
- On screens ≤ 768px, the toggle label is hidden to keep the top bar compact
- `.slot-info` subtext colors (`.venue-info`, `.faculty-name`) now use CSS variables so they adapt correctly in dark mode
- `#subjectTable td` now explicitly inherits `--table-cell-bg` and `--text-color` for full dark mode coverage

**`index.html`**
- Added the dark mode toggle widget (label + checkbox + styled slider) inside `.top-bar`, positioned between the GitHub link and Buy Me a Coffee button
- Cleaned up minor HTML inconsistencies (removed trailing space in `main.js` script `src` attribute)

**`JS/main.js`**
- Added `toggleDarkMode()` function that sets/removes `data-theme="dark"` on `<html>` and updates the toggle label text
- Added an IIFE `applySavedTheme()` that reads `localStorage` on page load and restores the user's last chosen theme — preference persists across sessions
- No changes to existing timetable, subject management, edit modal, or download logic

---

### 🎨 Dark Mode Color Palette
| Token | Light | Dark |
|-------|-------|------|
| `--primary-color` | `#2F3C7E` | `#4a5fc1` |
| `--secondary-color` | `#FBEAEB` | `#1a1a2e` |
| `--table-cell-bg` | `#ffffff` | `#252545` |
| `--modal-bg` | `#ffffff` | `#1e1e3a` |
| `--input-bg` | `#ffffff` | `#2a2a4a` |
| `--text-color` | `#2c3e50` | `#e0e0e0` |

---

### 📸 Screenshots
<!-- Add your before/after screenshots here -->
| Light Mode | Dark Mode |
|------------|-----------|
| _<img width="1916" height="859" alt="image" src="https://github.com/user-attachments/assets/08e89a6d-7c66-486d-a5b8-776e2bf88519" />_ | _<img width="1919" height="879" alt="image" src="https://github.com/user-attachments/assets/90716621-195f-4687-b913-078dc0561a82" />_ |

---

### ✅ Testing Checklist
- [x] Toggle switches correctly between light and dark mode
- [x] Theme preference persists on page refresh (via `localStorage`)
- [x] All table cells, modal, inputs, and footer render correctly in dark mode
- [x] Color picker, slot selection, and subject management work in both modes
- [x] Responsive layout looks correct on mobile in dark mode
- [x] PDF and JPEG download still functions correctly in both modes

---

### 🔗 Related
Closes #3 